### PR TITLE
fix crux-find-user-init-file

### DIFF
--- a/crux.el
+++ b/crux.el
@@ -340,7 +340,7 @@ Doesn't mess with special buffers."
 
 (defun crux-find-user-init-file ()
   "Edit the `user-init-file', in another window."
-  (interactive "P")
+  (interactive)
   (find-file-other-window user-init-file))
 
 (defun crux-find-shell-init-file ()


### PR DESCRIPTION
The point arg is not defined, but its also not necessary so I'm removing
the interactive flag.